### PR TITLE
feat(use): auto-detect global packages and update package.json

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path};
+use std::path::Path;
 
 pub fn run() {
     let config_path = Path::new("neonpack-config.toml");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,9 +2,10 @@ pub mod init;
 pub mod install;
 pub mod run;
 pub mod r#use;
-
+pub mod remove;
 
 use clap::Subcommand;
+use remove::RemoveArgs;
 
 #[derive(Subcommand)]
 pub enum Command {
@@ -12,6 +13,8 @@ pub enum Command {
     Init,
     Install(install::InstallArgs),
     Use { package: String },
+    Remove(RemoveArgs),
+
 }
 
 impl Command {
@@ -21,6 +24,7 @@ impl Command {
             Command::Init => init::run(),
             Command::Install(args) => install::run(args),
             Command::Use { package } => r#use::use_package(&package),
+            Command::Remove(args) => remove::run(args),
         }
     }
 }

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -1,0 +1,58 @@
+use std::fs;
+use std::path::Path;
+use clap::Args;
+use serde_json::Value;
+
+#[derive(Args)]
+pub struct RemoveArgs {
+    pub name: String,
+    #[arg(short, long)]
+    pub global: bool,
+}
+
+pub fn run(args: RemoveArgs) {
+    if args.global {
+        let global_path = dirs::home_dir()
+            .expect("No home directory found")
+            .join(".neonpack/lib")
+            .join(&args.name);
+
+        if global_path.exists() {
+            fs::remove_dir_all(&global_path)
+                .expect("Failed to remove global package directory");
+            println!("✓ Removed '{}' from global storage", args.name);
+        } else {
+            println!("⚠ '{}' not found in global storage", args.name);
+        }
+
+    } else {
+        let pkg_path = Path::new("package.json");
+        if !pkg_path.exists() {
+            eprintln!("package.json not found");
+            std::process::exit(1);
+        }
+
+        let content = fs::read_to_string(pkg_path).expect("Failed to read package.json");
+        let mut json: Value = serde_json::from_str(&content).expect("Invalid JSON in package.json");
+        let mut removed = false;
+
+        for section in ["dependencies", "devDependencies"] {
+            if let Some(table) = json.get_mut(section) {
+                if let Some(deps) = table.as_object_mut() {
+                    if deps.remove(&args.name).is_some() {
+                        removed = true;
+                    }
+                }
+            }
+        }
+
+        if removed {
+            fs::write(pkg_path, serde_json::to_string_pretty(&json).unwrap())
+                .expect("Failed to write package.json");
+            println!("✓ Removed '{}' from package.json", args.name);
+        } else {
+            eprintln!("Package '{}' not found in dependencies", args.name);
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,6 +1,7 @@
 use crate::core::rewrite::rewrite_imports;
 use clap::Args;
 use serde_json::Value;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -11,58 +12,83 @@ pub struct RunArgs {
 }
 
 pub fn run(args: RunArgs) {
-    if args.script == "dev" {
-        run_dev();
-    } else {
-        run_script(&args.script);
-    }
-}
-
-fn run_dev() {
-    let input = Path::new("src/index.js");
-    let output = Path::new(".neonpack-build/index.js");
-
-    if !input.exists() {
-        eprintln!("src/index.js not found");
+    let pkg_path = find_package_json().unwrap_or_else(|| {
+        eprintln!("package.json not found");
         std::process::exit(1);
-    }
+    });
 
-    if let Err(e) = rewrite_imports(input, output) {
-        eprintln!("Rewrite failed: {}", e);
-        std::process::exit(1);
-    }
-
-    let status = Command::new("node")
-        .arg(output)
-        .status()
-        .expect("Failed to start Node.js");
-
-    if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
-    }
-}
-
-fn run_script(script: &str) {
-    let pkg_path = PathBuf::from("package.json");
-    let content = fs::read_to_string(&pkg_path).expect("package.json not found");
-    let json: Value = serde_json::from_str(&content).expect("Invalid package.json");
+    let content = fs::read_to_string(&pkg_path).expect("Failed to read package.json");
+    let json: Value = serde_json::from_str(&content).expect("Invalid JSON in package.json");
 
     let cmd = json
         .get("scripts")
-        .and_then(|s| s.get(script))
+        .and_then(|s| s.get(&args.script))
         .and_then(|s| s.as_str())
         .unwrap_or_else(|| {
-            eprintln!("Script '{}' not found", script);
+            eprintln!("script '{}' not found in package.json", args.script);
             std::process::exit(1);
         });
 
-    let status = Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
-        .status()
-        .expect("Failed to run script");
+    if let Some(entry_file) = extract_entry_file(cmd) {
+        let input = Path::new(&entry_file);
+        let output = Path::new(".neonpack-build").join(input.file_name().unwrap());
 
-    if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
+        if !input.exists() {
+            eprintln!("File '{}' not found", input.display());
+            std::process::exit(1);
+        }
+
+        if let Err(e) = rewrite_imports(&input, &output) {
+            eprintln!("Failed to rewrite imports: {}", e);
+            std::process::exit(1);
+        }
+
+        println!("Running script '{}': node {}", args.script, output.display());
+
+        let status = Command::new("node")
+            .arg(output)
+            .current_dir(pkg_path.parent().unwrap_or_else(|| Path::new(".")))
+            .status()
+            .expect("Failed to run script");
+
+        if !status.success() {
+            std::process::exit(status.code().unwrap_or(1));
+        }
+    } else {
+        println!("Running script '{}': {}", args.script, cmd);
+
+        let status = Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .current_dir(pkg_path.parent().unwrap_or_else(|| Path::new(".")))
+            .status()
+            .expect("Failed to run script");
+
+        if !status.success() {
+            std::process::exit(status.code().unwrap_or(1));
+        }
+    }
+}
+
+fn find_package_json() -> Option<PathBuf> {
+    let mut dir = env::current_dir().ok()?;
+    loop {
+        let pkg = dir.join("package.json");
+        if pkg.is_file() {
+            return Some(pkg);
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    None
+}
+
+fn extract_entry_file(cmd: &str) -> Option<String> {
+    let parts: Vec<&str> = cmd.split_whitespace().collect();
+    if parts.len() == 2 && parts[0] == "node" {
+        Some(parts[1].to_string())
+    } else {
+        None
     }
 }

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -1,52 +1,89 @@
+use serde_json::{Map, Value};
 use std::fs;
-use std::path::Path;
-use toml_edit::{value};
-use toml_edit::Item;
-use toml_edit::DocumentMut;
-use toml_edit::Table;
+use std::path::{Path};
 
-/// Pins a globally installed package (from lockfile) to the project config
+/// `neonpack use <pkg>`: Activates package and updates package.json if missing
 pub fn use_package(pkg: &str) {
-    let config_path = Path::new("neonpack-config.toml");
-    let lock_path = Path::new("neonpack-lock.json");
+    let pkg_path = Path::new("package.json");
 
-    // Load lockfile
-    let lock_data = fs::read_to_string(lock_path)
-        .expect("neonpack-lock.json not found. Please install the package globally first.");
-    let lock_json: serde_json::Value = serde_json::from_str(&lock_data)
-        .expect("Failed to parse neonpack-lock.json");
-
-    let pkg_info = lock_json.get(pkg)
-        .expect("Package not found in neonpack-lock.json. Please run `neonpack install <pkg>` first.");
-
-    let version = pkg_info.get("version")
-        .and_then(|v| v.as_str())
-        .expect("Missing version in lockfile");
-
-    // Load config or create new
-    let mut doc = if config_path.exists() {
-        let content = fs::read_to_string(config_path).expect("Failed to read neonpack-config.toml");
-        content.parse::<DocumentMut>().expect("Invalid TOML in neonpack-config.toml")
-    } else {
-        // Create a new document with package and dependencies sections
-        let default_config = String::from(
-            r#"[package]
-name = "my-app"
-version = "0.1.0"
-
-[dependencies]
-"#,
-        );
-        default_config.parse::<DocumentMut>().expect("Failed to create new config")
-    };
-
-    // Ensure dependencies table exists and insert package
-    let dependencies = doc.entry("dependencies").or_insert(Item::Table(Table::new()));
-    if let Item::Table(table) = dependencies {
-        table.insert(pkg, value(version));
+    if !pkg_path.exists() {
+        eprintln!("package.json not found");
+        std::process::exit(1);
     }
 
-    // Save updated config
-    fs::write(config_path, doc.to_string()).expect("Failed to write neonpack-config.toml");
-    println!("Pinned {}@{} to neonpack-config.toml", pkg, version);
+    let content = fs::read_to_string(pkg_path).expect("Failed to read package.json");
+    let mut json: Value = serde_json::from_str(&content).expect("Invalid JSON in package.json");
+
+    // Try to get version from dependencies
+    let version = json
+        .get("dependencies")
+        .and_then(|deps| deps.get(pkg))
+        .and_then(|v| v.as_str())
+        .map(|v| v.to_string())
+        .or_else(|| get_latest_installed_version(pkg)); // fallback to global
+
+    let version = match version {
+        Some(v) => v,
+        None => {
+            eprintln!(
+                "Package '{}' not found locally or globally. Try `neonpack install {}`.",
+                pkg, pkg
+            );
+            std::process::exit(1);
+        }
+    };
+
+    let global_path = dirs::home_dir()
+        .expect("No home directory found")
+        .join(".neonpack/lib")
+        .join(pkg)
+        .join(&version);
+
+    if !global_path.exists() {
+        eprintln!(
+            "Package '{}'@{} not found in global storage. Try `neonpack install -g {}`.",
+            pkg, version, pkg
+        );
+        std::process::exit(1);
+    }
+
+    // If it wasn't in package.json, add it
+    if !json.get("dependencies").map_or(false, |v| v.is_object()) {
+        json["dependencies"] = Value::Object(Map::new());
+    }
+
+    let deps = json["dependencies"]
+        .as_object_mut()
+        .expect("dependencies must be an object");
+
+    if !deps.contains_key(pkg) {
+        deps.insert(pkg.to_string(), Value::String(version.clone()));
+        fs::write(pkg_path, serde_json::to_string_pretty(&json).unwrap())
+            .expect("Failed to write updated package.json");
+        println!("✓ Added '{}'@{} to package.json", pkg, version);
+    }
+
+    println!(
+        "✓ Activated {}@{} from {}",
+        pkg,
+        version,
+        global_path.display()
+    );
+}
+
+/// Get latest installed version from ~/.neonpack/lib/<pkg>
+fn get_latest_installed_version(pkg: &str) -> Option<String> {
+    let base = dirs::home_dir()?.join(".neonpack/lib").join(pkg);
+    if !base.exists() {
+        return None;
+    }
+
+    let mut versions: Vec<String> = fs::read_dir(&base)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+
+    versions.sort();
+    versions.pop()
 }

--- a/src/core/rewrite.rs
+++ b/src/core/rewrite.rs
@@ -1,22 +1,20 @@
+use crate::core::resolve::resolve_global_import;
+use regex::Regex;
 use std::fs;
 use std::path::Path;
-use regex::Regex;
-use crate::core::resolve::resolve_global_import;
 
 pub fn rewrite_imports(input: &Path, output: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let code = fs::read_to_string(input)?;
+    let import_regex_single =
+        Regex::new(r#"(\s*import\s+.*?\s+from\s+)'(?P<specifier>[^./][^']*)'"#)?;
+    let import_regex_double =
+        Regex::new(r#"(\s*import\s+.*?\s+from\s+)"(?P<specifier>[^./][^"]*)""#)?;
 
-    // Create regex patterns for different quote styles
-    let import_regex_single = Regex::new(r#"(\s*import\s+.*?\s+from\s+)'(?P<specifier>[^./][^']*)'"#)?;
-    let import_regex_double = Regex::new(r#"(\s*import\s+.*?\s+from\s+)"(?P<specifier>[^./][^"]*)""#)?;
+    let rewritten =
+        import_regex_single.replace_all(&code, |caps: &regex::Captures| rewrite_import(caps));
 
-    let rewritten = import_regex_single.replace_all(&code, |caps: &regex::Captures| {
-        rewrite_import(caps)
-    });
-
-    let rewritten = import_regex_double.replace_all(&rewritten, |caps: &regex::Captures| {
-        rewrite_import(caps)
-    });
+    let rewritten =
+        import_regex_double.replace_all(&rewritten, |caps: &regex::Captures| rewrite_import(caps));
 
     if let Some(parent) = output.parent() {
         fs::create_dir_all(parent)?;
@@ -32,10 +30,7 @@ fn rewrite_import(caps: &regex::Captures) -> String {
     match resolve_global_import(bare_specifier, None) {
         Some(resolved) => {
             if let Ok(abs_path) = resolved.canonicalize() {
-                let path_url = format!(
-                    "file://{}",
-                    abs_path.to_string_lossy().replace('\\', "/")
-                );
+                let path_url = format!("file://{}", abs_path.to_string_lossy().replace('\\', "/"));
                 format!("{}'{}'", import_stmt, path_url)
             } else {
                 caps[0].to_string()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Returns the global package path: ~/.neonpack/lib/<pkg>/<version>
 pub fn get_global_path(pkg: &str, version: &str) -> PathBuf {
     dirs::home_dir()
         .expect("Failed to get home directory")
@@ -11,7 +10,6 @@ pub fn get_global_path(pkg: &str, version: &str) -> PathBuf {
         .join(version)
 }
 
-/// Returns the internal project path: ./neonpack_modules/<pkg>/<version>
 pub fn get_internal_path(pkg: &str, version: &str) -> PathBuf {
     env::current_dir()
         .expect("Failed to get current directory")
@@ -20,7 +18,6 @@ pub fn get_internal_path(pkg: &str, version: &str) -> PathBuf {
         .join(version)
 }
 
-/// Returns true if inside a project (package.json exists)
 pub fn is_inside_project() -> bool {
     env::current_dir()
         .expect("Failed to get current directory")
@@ -28,7 +25,6 @@ pub fn is_inside_project() -> bool {
         .exists()
 }
 
-/// Get the latest installed version of a package from global store
 pub fn get_latest_installed_version(pkg: &str) -> Option<String> {
     let base_dir = dirs::home_dir()?.join(".neonpack/lib").join(pkg);
     if !base_dir.exists() {
@@ -45,7 +41,6 @@ pub fn get_latest_installed_version(pkg: &str) -> Option<String> {
     versions.pop()
 }
 
-/// Get pinned version from neonpack-config.toml
 pub fn get_version_from_config(pkg: &str) -> Option<String> {
     use toml_edit::Document;
     let config_path = Path::new("neonpack-config.toml");


### PR DESCRIPTION
Enhances the `neonpack use` command to detect globally installed packages if they are missing in package.json. Automatically adds the resolved version from ~/.neonpack/lib/<pkg>/<version> to the dependencies section.

Fixes borrow checker issue by separating dependency map initialization logic.

- Falls back to global version if not listed in package.json
- Writes the dependency to package.json automatically
- Improves developer experience and removes need for lock/config files