### PR TITLE
feat(cli): add --used and --all flags to `neonpack list` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "toml",
  "toml_edit",
  "ureq",
 ]
@@ -1168,6 +1169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1396,21 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ ureq = { version = "2.9.6", features = ["json"] }
 toml_edit = "0.23.1"
 bytes = "1"
 regex = "1.10"
+toml = "0.9.2"

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,16 @@
 set -e
 
 # Build in release mode
-sudo cargo build --release
-# Copy the binary
-sudo cp target/release/neonpack /home/mahesh/bin/neonpack
+cargo build --release
 
-echo "neonpack built and moved to /usr/local/bin/neonpack"
+# Define the destination directory
+DEST=${1:-"$HOME/.local/bin"}
+
+# Create the directory if it doesn't exist
+mkdir -p "$DEST"
+
+# Copy the binary
+cp target/release/neonpack "$DEST"
+
+echo "neonpack built and copied to $DEST"
+echo "Make sure $DEST is in your PATH"

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,75 @@
+use std::fs;
+use std::path::PathBuf;
+use clap::Args;
+
+
+use crate::core::resolve::{get_latest_installed_version, get_version_from_config};
+
+
+#[derive(Args)]
+pub struct ListArgs {
+    #[arg(long)]
+    pub used: bool,
+
+    #[arg(long)]
+    pub all: bool,
+}
+
+pub fn run(args: ListArgs) {
+    let show_used = args.used;
+    // let show_all = args.all;
+
+    let base = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".neonpack/lib");
+
+    if !base.exists() {
+        println!("No global packages installed.");
+        return;
+    }
+
+    println!("Global packages installed:\n");
+
+    let entries = match fs::read_dir(&base) {
+        Ok(entries) => entries,
+        Err(_) => {
+            println!("Unable to read package directory.");
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let pkg_name = entry.file_name().to_string_lossy().to_string();
+        let pkg_path = entry.path();
+        let versions = get_versions(&pkg_path);
+
+        for version in versions {
+            let in_use = is_version_used(&pkg_name, &version);
+
+            if show_used && !in_use {
+                continue;
+            }
+
+            let marker = if in_use { "✓ in use" } else { "" };
+
+            println!("  {:20} {:10} {}", pkg_name, version, marker);
+        }
+    }
+}
+
+fn get_versions(pkg_path: &PathBuf) -> Vec<String> {
+    fs::read_dir(pkg_path)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.ok()?.file_name().into_string().ok()?;
+            Some(name)
+        })
+        .collect()
+}
+
+fn is_version_used(pkg: &str, version: &str) -> bool {
+    get_version_from_config(pkg).as_deref() == Some(version)
+        || get_latest_installed_version(pkg).as_deref() == Some(version)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,8 @@ pub mod install;
 pub mod run;
 pub mod r#use;
 pub mod remove;
+pub mod list;
+
 
 use clap::Subcommand;
 use remove::RemoveArgs;
@@ -13,6 +15,7 @@ pub enum Command {
     Init,
     Install(install::InstallArgs),
     Use { package: String },
+    List(list::ListArgs),
     Remove(RemoveArgs),
 
 }
@@ -24,6 +27,7 @@ impl Command {
             Command::Init => init::run(),
             Command::Install(args) => install::run(args),
             Command::Use { package } => r#use::use_package(&package),
+            Command::List(args) => list::run(args),
             Command::Remove(args) => remove::run(args),
         }
     }


### PR DESCRIPTION
The `neonpack list` command now supports:
- `--used` to show only packages currently in use.
- `--all` (planned) for listing all installed packages, including unused ones.

Improves flexibility when managing globally installed packages.