### PR TITLE
feat(install): support installing all dependencies from package.json

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -10,46 +10,69 @@ use tar::Archive;
 
 #[derive(Args)]
 pub struct InstallArgs {
-    pub package: String,
+    /// Optional package name (e.g., lodash). If omitted, install from package.json
+    pub package: Option<String>,
 }
 
 pub fn run(args: InstallArgs) {
-    let pkg = args.package;
+    if let Some(pkg) = args.package {
+        install_package(&pkg);
+    } else {
+        install_from_package_json();
+    }
+}
+
+fn install_from_package_json() {
+    let content = fs::read_to_string("package.json")
+        .expect("package.json not found in current directory");
+
+    let json: Value = serde_json::from_str(&content).expect("Invalid JSON in package.json");
+
+    let deps = json.get("dependencies").and_then(|d| d.as_object());
+
+    if deps.is_none() {
+        println!("No dependencies found in package.json");
+        return;
+    }
+
+    for (pkg, _) in deps.unwrap() {
+        install_package(pkg);
+    }
+
+    println!("All dependencies installed.");
+}
+
+fn install_package(pkg: &str) {
     println!("Installing: {}", pkg);
 
     let url = format!("https://registry.npmjs.org/{}", pkg);
     let response = get(&url).expect("Failed to fetch package metadata");
     let meta: Value = response.json().expect("Invalid npm response");
 
-    let latest_version = match meta
+    let latest_version = meta
         .get("dist-tags")
         .and_then(|tags| tags.get("latest"))
         .and_then(|v| v.as_str())
-    {
-        Some(v) => v,
-        None => {
+        .unwrap_or_else(|| {
             eprintln!("Package '{}' not found on npm", pkg);
             std::process::exit(1);
-        }
-    };
-    let tarball_url = match meta
+        });
+
+    let tarball_url = meta
         .get("versions")
         .and_then(|v| v.get(latest_version))
         .and_then(|ver| ver.get("dist"))
         .and_then(|d| d.get("tarball"))
         .and_then(|t| t.as_str())
-    {
-        Some(url) => url,
-        None => {
+        .unwrap_or_else(|| {
             eprintln!("Tarball URL not found for '{}@{}'", pkg, latest_version);
             std::process::exit(1);
-        }
-    };
+        });
 
     let resp = get(tarball_url).expect("Failed to download tarball");
     let bytes = resp.bytes().expect("Failed to read tarball");
 
-    let global_path = get_global_path(&pkg, latest_version);
+    let global_path = get_global_path(pkg, latest_version);
     if global_path.exists() {
         println!("Already installed: {}/{}", pkg, latest_version);
     } else {
@@ -76,7 +99,6 @@ fn extract_tarball(data: &bytes::Bytes, target: &Path) {
         .filter_map(Result::ok)
         .for_each(|mut entry| {
             let path = entry.path().expect("Invalid path").into_owned();
-
             let rel_path = path.strip_prefix("package").unwrap_or(&path);
             let final_path = target.join(rel_path);
 


### PR DESCRIPTION
- Added functionality to install all dependencies when no package name is provided to `neonpack install`.
- Parses `package.json` in the current directory and installs each listed dependency with its specified version.
- Useful for batch installing libraries in new or cloned projects using the global package manager.
- Example usage: `neonpack install` (installs all from package.json)